### PR TITLE
PLAT-31643: Move redux_intro doc to enact-docs repo

### DIFF
--- a/pages/docs/tutorials/kitten-browser/data-and-state/index.md
+++ b/pages/docs/tutorials/kitten-browser/data-and-state/index.md
@@ -193,7 +193,7 @@ Enact ships with a set of configurable HOCs that can manage state for components
 	);
 
 > We wouldn't normally recommend managing your App's state this way but it's an easy way to get started. More advanced discussion of application state, and in particular Redux, is out of scope for this tutorial.
-> If you would like to learn more about using Redux to manage application and component state, please see our [Introduction to Redux](../../../developer-guide/redux_intro/)
+> If you would like to learn more about using Redux to manage application and component state, please see our [Introduction to Redux](../../../developer-guide/redux/redux_intro/)
 
 ## Conclusion
 


### PR DESCRIPTION
I went ahead and just put all (both) redux docs in `docs/developer-resources` since they're not really tools, per se.  Kitten Browser gets an update to point to the redux intro doc.