### PR TITLE
Page Sidebar to have dynamic height

### DIFF
--- a/src/components/Page/Page.less
+++ b/src/components/Page/Page.less
@@ -59,9 +59,10 @@
 		}
 
 		.sidebarColumn {
-			position: relative;
+			position: absolute;
+			overflow-y: auto;
 			height: 100%;
-			width: 25em;
+			width: 18em;
 			max-width: 30%;
 			margin: 0 @docs-sidebar-margin 1ex 0;
 			border-right: 1px solid @docs-sidebar-border-color;
@@ -115,6 +116,8 @@
 		}
 
 		.bodyColumn {
+			margin-left: 18em;
+
 			h1 {
 				margin-top: 0;
 			}
@@ -162,6 +165,10 @@
 				&.active {
 					transform: translateX(-@docs-site-edge-keepout);
 				}
+			}
+
+			.bodyColumn {
+				margin-left: 0;
 			}
 		}
 	}


### PR DESCRIPTION
Allow `sidebar` to have dynamic height and `overscroll` so that scrolling the sidebar won't affect the scrolling of the main content.

Also resized the `sidebar`'s width to make room for the scrollbar.

**maybe have `sidebar` position fixed, so that its height is the height of the window?
The only thing I haven't figured out is how to shrink the `sidebar` height to make way for the footer when scrolling the main content to the bottom.

Enact-DCO-1.0-Signed-off-by: Teck Liew teck.liew@lge.com